### PR TITLE
mc-9607 Detect enumeration values

### DIFF
--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelImporterProviderServiceParameters.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelImporterProviderServiceParameters.groovy
@@ -33,10 +33,10 @@ abstract class DatabaseDataModelImporterProviderServiceParameters<K extends Data
             'A suffix to attach to the end of the auto-imported DataModel name.',
             'This should only be used if the DataModel name property is not supplied.',
             'The suffix will be appended in the form ${modelName}_${suffix}.'],
-        order = 0,
+        order = 4,
         optional = true,
         group = @ImportGroupConfig(
-            name = 'DataModel',
+            name = 'Model',
             order = 0
         ))
     String dataModelNameSuffix
@@ -54,6 +54,30 @@ abstract class DatabaseDataModelImporterProviderServiceParameters<K extends Data
             order = 2
         ))
     String databaseNames
+
+    @ImportParameterConfig(
+        displayName = 'Detect Enumerations',
+        description = 'Whether to treat columns with small numbers of unique values as enumerations',
+        order = 5,
+        optional = true,
+        group = @ImportGroupConfig(
+                name = 'Database Import Details',
+                order = 2
+        )
+    )
+    Boolean detectEnumerations = false
+
+    @ImportParameterConfig(
+        displayName = 'Maximum Enumerations',
+        description = 'The maximum number of unique values to be interpreted as a defined enumeration',
+        order = 6,
+        optional = true,
+        group = @ImportGroupConfig(
+                name = 'Database Import Details',
+                order = 2
+        )
+    )
+    Integer maxEnumerations = 20
 
     @ImportParameterConfig(
         displayName = 'Database Host',
@@ -108,30 +132,6 @@ abstract class DatabaseDataModelImporterProviderServiceParameters<K extends Data
             order = 1
         ))
     Boolean databaseSSL
-
-    @ImportParameterConfig(
-        displayName = 'Detect Enumerations',
-        description = 'Whether to treat columns with small numbers of unique values as enumerations',
-        order = 1,
-        optional = true,
-        group = @ImportGroupConfig(
-                name = 'Configuration',
-                order = 2
-        )
-    )
-    Boolean detectEnumerations = false
-
-    @ImportParameterConfig(
-        displayName = 'Maximum Enumerations',
-        description = 'The maximum number of unique values to be interpreted as a defined enumeration',
-        order = 2,
-        optional = true,
-        group = @ImportGroupConfig(
-                name = 'Configuration',
-                order = 2
-        )
-    )
-    Integer maxEnumerations = 20
 
     Integer getDatabasePort() {
         databasePort = databasePort ?: defaultPort

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelImporterProviderServiceParameters.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelImporterProviderServiceParameters.groovy
@@ -109,6 +109,30 @@ abstract class DatabaseDataModelImporterProviderServiceParameters<K extends Data
         ))
     Boolean databaseSSL
 
+    @ImportParameterConfig(
+        displayName = 'Detect Enumerations',
+        description = 'Whether to treat columns with small numbers of unique values as enumerations',
+        order = 1,
+        optional = true,
+        group = @ImportGroupConfig(
+                name = 'Configuration',
+                order = 2
+        )
+    )
+    Boolean detectEnumerations = false
+
+    @ImportParameterConfig(
+        displayName = 'Maximum Enumerations',
+        description = 'The maximum number of unique values to be interpreted as a defined enumeration',
+        order = 2,
+        optional = true,
+        group = @ImportGroupConfig(
+                name = 'Configuration',
+                order = 2
+        )
+    )
+    Integer maxEnumerations = 20
+
     Integer getDatabasePort() {
         databasePort = databasePort ?: defaultPort
         databasePort
@@ -128,6 +152,10 @@ abstract class DatabaseDataModelImporterProviderServiceParameters<K extends Data
         databaseUsername = properties.getProperty 'import.database.username'
         databasePassword = properties.getProperty 'import.database.password'
         databaseSSL = properties.getProperty('import.database.ssl') as Boolean
+
+        if (!maxEnumerations) {
+            maxEnumerations = 20
+        }
 
         try {
             databasePort = properties.getProperty('import.database.port') as Integer


### PR DESCRIPTION
Add generic detection of enumeration values.

Subclasses should override the new methods for counting and getting distinct values, and for choosing which data types to check as possible enumerations.

See corresponding pull requests for mdm-plugin-database-sqlserver and mdm-plugin-database-postgresql.