### PR TITLE
Feature/mc 9608

### DIFF
--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -897,7 +897,8 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
         log.info("Finished getEnumerationValueDistribution query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
 
         results.collectEntries{
-            [(it.enumeration_value): it.enumeration_count]
+            // null values are not counted by a group by query, so skip
+            it.enumeration_value != null ? [(it.enumeration_value): it.enumeration_count] : [:]
         }
     }
 }

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -755,16 +755,16 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
      * @param schemaName
      * @return
      */
-    private Integer getApproxCount(Connection connection, String tableName, String schemaName = null) {
+    private Long getApproxCount(Connection connection, String tableName, String schemaName = null) {
 
-        Integer approxCount = 0
+        Long approxCount = 0
         List<String> queryStrings = approxCountQueryString(tableName, schemaName)
         for (String queryString: queryStrings) {
             PreparedStatement preparedStatement = connection.prepareStatement(queryString)
             List<Map<String, Object>> results = executeStatement(preparedStatement)
 
             if (results && results[0].approx_count != null) {
-                approxCount =  (Integer) results[0].approx_count
+                approxCount =  (Long) results[0].approx_count
                 break
             }
         }

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -483,7 +483,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
     }
 
     void updateDataModelWithEnumerationsAndSummaryMetadata(User user, S parameters, DataModel dataModel, Connection connection) {
-        log.info('Starting enumeration and summary metedata detection')
+        log.debug('Starting enumeration and summary metadata detection')
         long startTime = System.currentTimeMillis()
         dataModel.childDataClasses.each { DataClass schemaClass ->
             schemaClass.dataClasses.each { DataClass tableClass ->
@@ -548,7 +548,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
             }
         }
 
-        log.info('Finished enumeration and summary metadata detection in {}', Utils.timeTaken(startTime))
+        log.debug('Finished enumeration and summary metadata detection in {}', Utils.timeTaken(startTime))
     }
 
     void replacePrimitiveTypeWithEnumerationType(DataModel dataModel, DataElement de, DataType primitiveType, EnumerationType enumerationType, List<Map<String, Object>> results) {
@@ -772,33 +772,33 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
     }
 
     int getCountDistinctColumnValues(Connection connection, SamplingStrategy samplingStrategy, String columnName, String tableName, String schemaName = null) {
-        log.info("Starting getCountDistinctColumnValues query for ${tableName}.${columnName}")
+        log.debug("Starting getCountDistinctColumnValues query for ${tableName}.${columnName}")
         long startTime = System.currentTimeMillis()
         String queryString = countDistinctColumnValuesQueryString(samplingStrategy, columnName, tableName, schemaName)
         final PreparedStatement preparedStatement = connection.prepareStatement(queryString)
         final List<Map<String, Object>> results = executeStatement(preparedStatement)
-        log.info("Finished getCountDistinctColumnValues query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
+        log.debug("Finished getCountDistinctColumnValues query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
         (int) results[0].count
     }
 
     private List<Map<String, Object>> getDistinctColumnValues(Connection connection, SamplingStrategy samplingStrategy, String columnName, String tableName, String schemaName = null) {
-        log.info("Starting getDistinctColumnValues query for ${tableName}.${columnName}")
+        log.debug("Starting getDistinctColumnValues query for ${tableName}.${columnName}")
         long startTime = System.currentTimeMillis()
         String queryString = distinctColumnValuesQueryString(samplingStrategy, columnName, tableName, schemaName)
         final PreparedStatement preparedStatement = connection.prepareStatement(queryString)
         final List<Map<String, Object>> results = executeStatement(preparedStatement)
-        log.info("Finished getDistinctColumnValues query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
+        log.debug("Finished getDistinctColumnValues query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
         results
     }
 
     private Pair getMinMaxColumnValues(Connection connection, SamplingStrategy samplingStrategy, String columnName, String tableName, String schemaName = null) {
-        log.info("Starting getMinMaxColumnValues query for ${tableName}.${columnName}")
+        log.debug("Starting getMinMaxColumnValues query for ${tableName}.${columnName}")
         long startTime = System.currentTimeMillis()
         String queryString = minMaxColumnValuesQueryString(samplingStrategy, columnName, tableName, schemaName)
         final PreparedStatement preparedStatement = connection.prepareStatement(queryString)
         final List<Map<String, Object>> results = executeStatement(preparedStatement)
 
-        log.info("Finished getMinMaxColumnValues query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
+        log.debug("Finished getMinMaxColumnValues query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
 
         new Pair(results[0].min_value, results[0].max_value)
     }
@@ -813,7 +813,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
      * @return
      */
     private Long getApproxCount(Connection connection, String tableName, String schemaName = null) {
-        log.info("Starting getApproxCouunt query for ${tableName}")
+        log.debug("Starting getApproxCouunt query for ${tableName}")
         long startTime = System.currentTimeMillis()
         Long approxCount = 0
         List<String> queryStrings = approxCountQueryString(tableName, schemaName)
@@ -827,7 +827,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
             }
         }
 
-        log.info("Finished getApproxCount query for ${tableName} in {}", Utils.timeTaken(startTime))
+        log.debug("Finished getApproxCount query for ${tableName} in {}", Utils.timeTaken(startTime))
 
         return approxCount
     }
@@ -871,14 +871,14 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
     private Map<String, Long> getColumnRangeDistribution(Connection connection, SamplingStrategy samplingStrategy,
                                                             DataType dataType, AbstractIntervalHelper intervalHelper,
                                                             String columnName, String tableName, String schemaName = null) {
-        log.info("Starting getColumnRangeDistribution query for ${tableName}.${columnName}")
+        log.debug("Starting getColumnRangeDistribution query for ${tableName}.${columnName}")
         long startTime = System.currentTimeMillis()
         String queryString = columnRangeDistributionQueryString(samplingStrategy, dataType, intervalHelper, columnName, tableName, schemaName)
 
         final PreparedStatement preparedStatement = connection.prepareStatement(queryString)
         List<Map<String, Object>> results = executeStatement(preparedStatement)
         preparedStatement.close()
-        log.info("Finished getColumnRangeDistribution query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
+        log.debug("Finished getColumnRangeDistribution query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
 
         results.collectEntries{
             [(it.interval_label): it.interval_count]
@@ -887,14 +887,14 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
 
     protected Map<String, Long> getEnumerationValueDistribution(Connection connection, SamplingStrategy samplingStrategy,
                                                          String columnName, String tableName, String schemaName = null) {
-        log.info("Starting getEnumerationValueDistribution query for ${tableName}.${columnName}")
+        log.debug("Starting getEnumerationValueDistribution query for ${tableName}.${columnName}")
         long startTime = System.currentTimeMillis()
         String queryString = enumerationValueDistributionQueryString(samplingStrategy, columnName, tableName, schemaName)
 
         final PreparedStatement preparedStatement = connection.prepareStatement(queryString)
         List<Map<String, Object>> results = executeStatement(preparedStatement)
         preparedStatement.close()
-        log.info("Finished getEnumerationValueDistribution query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
+        log.debug("Finished getEnumerationValueDistribution query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
 
         results.collectEntries{
             // Convert a null key to string 'NULL'. There is a risk of collision with a string value 'NULL'

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -522,6 +522,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
         addPrimaryKeyAndUniqueConstraintInformation dataModel, connection
         addIndexInformation dataModel, connection
         addForeignKeyInformation dataModel, connection
+        addMetadata dataModel, connection
     }
 
     void addStandardConstraintInformation(DataModel dataModel, Connection connection) throws ApiException, SQLException {
@@ -626,6 +627,16 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
                 columnElement.addToMetadata(namespace, "foreign_key_columns", row.reference_column_name as String, dataModel.createdBy)
             }
         }
+    }
+
+    /**
+     * Subclasses may override this method and use vendor specific queries to add metadata / extended properties /
+     * comments to the DataModel and its constituent parts.
+     * @param dataModel
+     * @param connection
+     */
+    void addMetadata(DataModel dataModel, Connection connection) {
+        return
     }
 
     Connection getConnection(String databaseName, S parameters) throws ApiException, ApiBadRequestException {

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -756,23 +756,33 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
     }
 
     int getCountDistinctColumnValues(Connection connection, SamplingStrategy samplingStrategy, String columnName, String tableName, String schemaName = null) {
+        log.info("Starting getCountDistinctColumnValues query for ${tableName}.${columnName}")
+        long startTime = System.currentTimeMillis()
         String queryString = countDistinctColumnValuesQueryString(samplingStrategy, columnName, tableName, schemaName)
         final PreparedStatement preparedStatement = connection.prepareStatement(queryString)
         final List<Map<String, Object>> results = executeStatement(preparedStatement)
+        log.info("Finished getCountDistinctColumnValues query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
         (int) results[0].count
     }
 
     private List<Map<String, Object>> getDistinctColumnValues(Connection connection, SamplingStrategy samplingStrategy, String columnName, String tableName, String schemaName = null) {
+        log.info("Starting getDistinctColumnValues query for ${tableName}.${columnName}")
+        long startTime = System.currentTimeMillis()
         String queryString = distinctColumnValuesQueryString(samplingStrategy, columnName, tableName, schemaName)
         final PreparedStatement preparedStatement = connection.prepareStatement(queryString)
         final List<Map<String, Object>> results = executeStatement(preparedStatement)
+        log.info("Finished getDistinctColumnValues query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
         results
     }
 
     private Pair getMinMaxColumnValues(Connection connection, SamplingStrategy samplingStrategy, String columnName, String tableName, String schemaName = null) {
+        log.info("Starting getMinMaxColumnValues query for ${tableName}.${columnName}")
+        long startTime = System.currentTimeMillis()
         String queryString = minMaxColumnValuesQueryString(samplingStrategy, columnName, tableName, schemaName)
         final PreparedStatement preparedStatement = connection.prepareStatement(queryString)
         final List<Map<String, Object>> results = executeStatement(preparedStatement)
+
+        log.info("Finished getMinMaxColumnValues query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
 
         new Pair(results[0].min_value, results[0].max_value)
     }
@@ -787,7 +797,8 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
      * @return
      */
     private Long getApproxCount(Connection connection, String tableName, String schemaName = null) {
-
+        log.info("Starting getApproxCouunt query for ${tableName}")
+        long startTime = System.currentTimeMillis()
         Long approxCount = 0
         List<String> queryStrings = approxCountQueryString(tableName, schemaName)
         for (String queryString: queryStrings) {
@@ -799,6 +810,8 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
                 break
             }
         }
+
+        log.info("Finished getApproxCount query for ${tableName} in {}", Utils.timeTaken(startTime))
 
         return approxCount
     }
@@ -842,11 +855,14 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
     private Map<String, Long> getColumnRangeDistribution(Connection connection, SamplingStrategy samplingStrategy,
                                                             DataType dataType, AbstractIntervalHelper intervalHelper,
                                                             String columnName, String tableName, String schemaName = null) {
+        log.info("Starting getColumnRangeDistribution query for ${tableName}.${columnName}")
+        long startTime = System.currentTimeMillis()
         String queryString = columnRangeDistributionQueryString(samplingStrategy, dataType, intervalHelper, columnName, tableName, schemaName)
 
         final PreparedStatement preparedStatement = connection.prepareStatement(queryString)
         List<Map<String, Object>> results = executeStatement(preparedStatement)
         preparedStatement.close()
+        log.info("Finished getColumnRangeDistribution query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
 
         results.collectEntries{
             [(it.interval_label): it.interval_count]

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -40,6 +40,7 @@ import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.Abstrac
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.DateIntervalHelper
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.DecimalIntervalHelper
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.IntegerIntervalHelper
+import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.LongIntervalHelper
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.SummaryMetadataHelper
 import uk.ac.ox.softeng.maurodatamapper.security.User
 
@@ -274,6 +275,16 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
      * @return boolean
      */
     boolean isColumnForIntegerSummary(DataType dataType) {
+        false
+    }
+
+    /**
+     * Does the dataType represent a column that should be summarised as a long?
+     * Subclasses can override and use database specific types.
+     * @param dataType
+     * @return boolean
+     */
+    boolean isColumnForLongSummary(DataType dataType) {
         false
     }
 
@@ -516,7 +527,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
                 } else {
                     tableClass.dataElements.each { DataElement de ->
                         DataType dt = de.dataType
-                        if (isColumnForDateSummary(dt) || isColumnForDecimalSummary(dt) || isColumnForIntegerSummary(dt)) {
+                        if (isColumnForDateSummary(dt) || isColumnForDecimalSummary(dt) || isColumnForIntegerSummary(dt) || isColumnForLongSummary(dt)) {
                             Pair minMax = getMinMaxColumnValues(connection, samplingStrategy, de.label, tableClass.label, schemaClass.label)
 
                             //aValue is the MIN, bValue is the MAX. If they are not null then calculate the range etc...
@@ -817,7 +828,9 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
     }
 
     private AbstractIntervalHelper getIntervalHelper(DataType dt, Pair minMax) {
-        if (isColumnForIntegerSummary(dt)) {
+        if (isColumnForLongSummary(dt)) {
+            return new LongIntervalHelper((Long) minMax.aValue, (Long) minMax.bValue)
+        } else if (isColumnForIntegerSummary(dt)) {
             return new IntegerIntervalHelper((Integer) minMax.aValue, (Integer) minMax.bValue)
         } else if (isColumnForDateSummary(dt)) {
             return new DateIntervalHelper(((java.util.Date) minMax.aValue).toLocalDateTime(), ((java.util.Date) minMax.bValue).toLocalDateTime())

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -466,7 +466,9 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
             schemaClass.dataClasses.each { DataClass tableClass ->
                 SamplingStrategy samplingStrategy = getSamplingStrategy(parameters)
                 samplingStrategy.approxCount = getApproxCount(connection, tableClass.label, schemaClass.label)
-                samplingStrategy.tableType = getTableType(connection, tableClass.label, schemaClass.label, dataModel.label)
+                if (samplingStrategy.requiresTableType()) {
+                    samplingStrategy.tableType = getTableType(connection, tableClass.label, schemaClass.label, dataModel.label)
+                }
 
                 if (!samplingStrategy.canSample() && samplingStrategy.approxCount > samplingStrategy.threshold) {
                     log.info("Not calculating enumerations for ${samplingStrategy.tableType} ${tableClass.label} with approx rowcount ${samplingStrategy.approxCount} and threshold ${samplingStrategy.threshold}")
@@ -520,7 +522,9 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
             schemaClass.dataClasses.each { DataClass tableClass ->
                 SamplingStrategy samplingStrategy = getSamplingStrategy(parameters)
                 samplingStrategy.approxCount = getApproxCount(connection, tableClass.label, schemaClass.label)
-                samplingStrategy.tableType = getTableType(connection, tableClass.label, schemaClass.label, dataModel.label)
+                if (samplingStrategy.requiresTableType()) {
+                    samplingStrategy.tableType = getTableType(connection, tableClass.label, schemaClass.label, dataModel.label)
+                }
 
                 if (!samplingStrategy.canSample() && samplingStrategy.approxCount > samplingStrategy.threshold) {
                     log.info("Not calculating summary metadata for ${samplingStrategy.tableType} ${tableClass.label} with approx rowcount ${samplingStrategy.approxCount} and threshold ${samplingStrategy.threshold}")

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -523,7 +523,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
                             if (!(minMax.aValue == null) && !(minMax.bValue == null)) {
                                 AbstractIntervalHelper intervalHelper = getIntervalHelper(dt, minMax)
 
-                                Map<String, Integer> valueDistribution = getColumnRangeDistribution(connection, samplingStrategy, dt, intervalHelper, de.label, tableClass.label, schemaClass.label)
+                                Map<String, Long> valueDistribution = getColumnRangeDistribution(connection, samplingStrategy, dt, intervalHelper, de.label, tableClass.label, schemaClass.label)
                                 if (valueDistribution) {
                                     String description = 'Value Distribution';
                                     if (samplingStrategy.useSampling()) {
@@ -826,7 +826,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
         }
     }
 
-    private Map<String, Integer> getColumnRangeDistribution(Connection connection, SamplingStrategy samplingStrategy,
+    private Map<String, Long> getColumnRangeDistribution(Connection connection, SamplingStrategy samplingStrategy,
                                                             DataType dataType, AbstractIntervalHelper intervalHelper,
                                                             String columnName, String tableName, String schemaName = null) {
         String queryString = columnRangeDistributionQueryString(samplingStrategy, dataType, intervalHelper, columnName, tableName, schemaName)

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -385,7 +385,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
 
         String sql = """
         SELECT ${escapeIdentifier(schemaName)}.${escapeIdentifier(tableName)}.${escapeIdentifier(columnName)} AS enumeration_value,
-        COUNT(${escapeIdentifier(schemaName)}.${escapeIdentifier(tableName)}.${escapeIdentifier(columnName)}) AS enumeration_count
+        COUNT(*) AS enumeration_count
         FROM ${escapeIdentifier(schemaName)}.${escapeIdentifier(tableName)} 
         ${samplingStrategy.samplingClause()}
         GROUP BY ${escapeIdentifier(schemaName)}.${escapeIdentifier(tableName)}.${escapeIdentifier(columnName)}
@@ -897,8 +897,9 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
         log.info("Finished getEnumerationValueDistribution query for ${tableName}.${columnName} in {}", Utils.timeTaken(startTime))
 
         results.collectEntries{
-            // null values are not counted by a group by query, so skip
-            it.enumeration_value != null ? [(it.enumeration_value): it.enumeration_count] : [:]
+            // Convert a null key to string 'NULL'. There is a risk of collision with a string value 'NULL'
+            // from the database.
+            it.enumeration_value != null ? [(it.enumeration_value): it.enumeration_count] : ['NULL': it.enumeration_count]
         }
     }
 }

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -47,6 +47,7 @@ import groovy.json.JsonOutput
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 import java.sql.Connection
 import java.sql.PreparedStatement
@@ -436,6 +437,8 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
     }
 
     void updateDataModelWithEnumerations(User user, SamplingStrategy samplingStrategy, int maxEnumerations, DataModel dataModel, Connection connection) {
+        log.info('Starting enumeration detection')
+        long startTime = System.currentTimeMillis()
         dataModel.childDataClasses.each { DataClass schemaClass ->
             schemaClass.dataClasses.each { DataClass tableClass ->
                 //Decide whether or not to use sampling
@@ -457,11 +460,15 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
                 }
             }
         }
+        log.info('Finished enumeration detection in {}', Utils.timeTaken(startTime))
     }
 
     void replacePrimitiveTypeWithEnumerationType(DataModel dataModel, DataElement de, DataType primitiveType, EnumerationType enumerationType, List<Map<String, Object>> results) {
         results.each {
-            enumerationType.addToEnumerationValues(new EnumerationValue(key: it.distinct_value, value: it.distinct_value))
+            //null is not a value, so skip it
+            if (it.distinct_value != null) {
+                enumerationType.addToEnumerationValues(new EnumerationValue(key: it.distinct_value, value: it.distinct_value))
+            }
         }
 
         primitiveType.removeFromDataElements(de)
@@ -480,6 +487,8 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
      * @param connection
      */
     void updateDataModelWithSummaryMetadata(User user, SamplingStrategy samplingStrategy, DataModel dataModel, Connection connection) {
+        log.info('Starting summary metadata')
+        long startTime = System.currentTimeMillis()
         dataModel.childDataClasses.each { DataClass schemaClass ->
             schemaClass.dataClasses.each { DataClass tableClass ->
                 //Decide whether or not to use sampling
@@ -509,6 +518,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
                 }
             }
         }
+        log.info('Finished summary metadata in {}', Utils.timeTaken(startTime))
     }
 
     /**

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -742,7 +742,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
             PreparedStatement preparedStatement = connection.prepareStatement(queryString)
             List<Map<String, Object>> results = executeStatement(preparedStatement)
 
-            if (results[0].approx_count != null) {
+            if (results && results[0].approx_count != null) {
                 approxCount =  (Integer) results[0].approx_count
                 break
             }

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
@@ -23,6 +23,7 @@ class SamplingStrategy {
     Integer threshold
     BigDecimal percentage
     Long approxCount
+    String tableType
 
     SamplingStrategy() {
         this.enabled = false
@@ -33,15 +34,24 @@ class SamplingStrategy {
         this.threshold = threshold
         this.percentage = percentage
         this.approxCount = 0
+        this.tableType = ""
     }
 
     /**
-     * Only use sampling if sampling is enabled, both threshold and percentage are > 0, and the number
-     * of rows exceeds the (non-zero) threshold for sampling.
+     * Sampling does not work on Views.
+     * @return true if tableType is BASE TABLE
+     */
+    public boolean canSample() {
+        this.tableType == 'BASE TABLE'
+    }
+
+    /**
+     * Only use sampling if sampling is enabled, both threshold and percentage are > 0, the number
+     * of rows exceeds the (non-zero) threshold for sampling, and we are looking at a table (not a view)
      * @return
      */
     public boolean useSampling() {
-       this.enabled && this.threshold > 0 && this.percentage > 0 && this.approxCount > this.threshold
+       this.enabled && this.threshold > 0 && this.percentage > 0 && this.approxCount > this.threshold && this.canSample()
     }
 
     public Integer scaleFactor() {

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
@@ -22,7 +22,7 @@ class SamplingStrategy {
     boolean enabled
     Integer threshold
     BigDecimal percentage
-    Integer approxCount
+    Long approxCount
 
     SamplingStrategy() {
         this.enabled = false

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020-2021 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.plugins.database
+
+class SamplingStrategy {
+
+    boolean enabled
+    Integer threshold
+    BigDecimal percentage
+    Integer approxCount
+
+    SamplingStrategy() {
+        this.enabled = false
+    }
+
+    SamplingStrategy(Integer threshold, BigDecimal percentage) {
+        this.enabled = true
+        this.threshold = threshold
+        this.percentage = percentage
+        this.approxCount = 0
+    }
+
+    /**
+     * Only use sampling if sampling is enabled, both threshold and percentage are > 0, and the number
+     * of rows exceeds the (non-zero) threshold for sampling.
+     * @return
+     */
+    public boolean useSampling() {
+       this.enabled && this.threshold > 0 && this.percentage > 0 && this.approxCount > this.threshold
+    }
+
+    public Integer scaleFactor() {
+        if (this.useSampling()) {
+            return 100 / this.percentage
+        } else {
+            return 1
+        }
+    }
+}

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
@@ -38,6 +38,14 @@ class SamplingStrategy {
     }
 
     /**
+     * Does this SamplingStrategy need to know the table type (BASE TABLE or VIEW) in order to decide if sampling is possible?
+     * @return
+     */
+    public boolean requiresTableType() {
+        true
+    }
+
+    /**
      * Sampling does not work on Views.
      * @return true if tableType is BASE TABLE
      */

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/SamplingStrategy.groovy
@@ -19,18 +19,15 @@ package uk.ac.ox.softeng.maurodatamapper.plugins.database
 
 class SamplingStrategy {
 
-    boolean enabled
     Integer threshold
     BigDecimal percentage
     Long approxCount
     String tableType
 
     SamplingStrategy() {
-        this.enabled = false
     }
 
     SamplingStrategy(Integer threshold, BigDecimal percentage) {
-        this.enabled = true
         this.threshold = threshold
         this.percentage = percentage
         this.approxCount = 0
@@ -41,16 +38,16 @@ class SamplingStrategy {
      * Does this SamplingStrategy need to know the table type (BASE TABLE or VIEW) in order to decide if sampling is possible?
      * @return
      */
-    public boolean requiresTableType() {
+    boolean requiresTableType() {
         true
     }
 
     /**
-     * Sampling does not work on Views.
-     * @return true if tableType is BASE TABLE
+     * By default, no sampling. Subclasses should override.
+     * @return
      */
-    public boolean canSample() {
-        this.tableType == 'BASE TABLE'
+    boolean canSample() {
+        false
     }
 
     /**
@@ -58,11 +55,19 @@ class SamplingStrategy {
      * of rows exceeds the (non-zero) threshold for sampling, and we are looking at a table (not a view)
      * @return
      */
-    public boolean useSampling() {
-       this.enabled && this.threshold > 0 && this.percentage > 0 && this.approxCount > this.threshold && this.canSample()
+    boolean useSampling() {
+       this.canSample() && this.threshold > 0 && this.percentage > 0 && this.approxCount > this.threshold
     }
 
-    public Integer scaleFactor() {
+    /**
+     * Return a sampling clause. Subclasses should override wth vendor specific sampling clauses
+     * @return
+     */
+    String samplingClause() {
+        ""
+    }
+
+    Integer scaleFactor() {
         if (this.useSampling()) {
             return 100 / this.percentage
         } else {

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/DecimalIntervalHelper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/DecimalIntervalHelper.groovy
@@ -29,7 +29,9 @@ class DecimalIntervalHelper extends AbstractIntervalHelper<BigDecimal> {
     void calculateInterval() {
         difference = maxValue - minValue
 
-        if (0 < difference && difference <= 0.1 ) {
+        if (difference == 0) {
+            intervalLength = 1.0
+        } else if (0 < difference && difference <= 0.1 ) {
             intervalLength = 0.02
         } else if (0.1 < difference && difference <= 1 ) {
             intervalLength = 0.2
@@ -65,10 +67,23 @@ class DecimalIntervalHelper extends AbstractIntervalHelper<BigDecimal> {
             intervalLength = 2000000
         } else if (20000000 < difference && difference <= 100000000 ) {
             intervalLength = 10000000
-        } else intervalLength = maxValue - minValue / 10
+        }  else {
+            Double base = Math.log10((Double) ((maxValue - minValue)  / 10))
+            intervalLength = (BigDecimal) Math.pow(10, Math.ceil(base))
+        }
 
-        firstIntervalStart = minValue.divideAndRemainder(intervalLength)[0] * intervalLength
-        lastIntervalStart = maxValue.divideAndRemainder(intervalLength)[0] * intervalLength
+        BigDecimal[] minValueDivideAndRemainder = minValue.divideAndRemainder(intervalLength)
+        firstIntervalStart = minValueDivideAndRemainder[0] * intervalLength
+        //For negative minima which do not align with an interval start, shift the interval one step to the left
+        if (Math.abs(minValueDivideAndRemainder[1]) > 0 && minValue < 0) {
+            firstIntervalStart = firstIntervalStart - intervalLength
+        }
+
+        BigDecimal[] maxValueDivideAndRemainder = maxValue.divideAndRemainder(intervalLength)
+        lastIntervalStart = maxValueDivideAndRemainder[0] * intervalLength
+        if (Math.abs(maxValueDivideAndRemainder[1]) > 0 && maxValue < 0) {
+            lastIntervalStart = lastIntervalStart - intervalLength
+        }
     }
 
     void calculateIntervalStarts() {

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/IntegerIntervalHelper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/IntegerIntervalHelper.groovy
@@ -32,7 +32,9 @@ class IntegerIntervalHelper extends AbstractIntervalHelper<Integer> {
 
         difference = maxValue - minValue
 
-        if (1 < difference && difference <= 5 ) {
+        if (difference <= 1) {
+            intervalLength = 1
+        } else if (1 < difference && difference <= 5 ) {
             intervalLength = 1
         } else if (5 < difference && difference <= 10 ) {
             intervalLength = 2
@@ -64,10 +66,21 @@ class IntegerIntervalHelper extends AbstractIntervalHelper<Integer> {
             intervalLength = 2000000
         } else if (20000000 < difference && difference <= 100000000 ) {
             intervalLength = 10000000
-        } else intervalLength = (Integer) ((maxValue - minValue)  / 10)
+        } else {
+            Double base = Math.log10((Double) ((maxValue - minValue)  / 10))
+            intervalLength = (Integer) Math.pow(10, Math.ceil(base))
+        }
 
         firstIntervalStart = minValue.intdiv(intervalLength) * intervalLength
+        //For negative minima which do not align with an interval start, shift the interval one step to the left
+        if (Math.abs(minValue % intervalLength) > 0 && minValue < 0) {
+            firstIntervalStart = firstIntervalStart - intervalLength
+        }
         lastIntervalStart = maxValue.intdiv(intervalLength) * intervalLength
+        if (Math.abs(maxValue % intervalLength) > 0 && maxValue < 0) {
+            lastIntervalStart = lastIntervalStart - intervalLength
+        }
+
     }
 
     @Override

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/IntegerIntervalHelper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/IntegerIntervalHelper.groovy
@@ -64,7 +64,7 @@ class IntegerIntervalHelper extends AbstractIntervalHelper<Integer> {
             intervalLength = 2000000
         } else if (20000000 < difference && difference <= 100000000 ) {
             intervalLength = 10000000
-        } else intervalLength = maxValue - minValue / 10
+        } else intervalLength = (Integer) ((maxValue - minValue)  / 10)
 
         firstIntervalStart = minValue.intdiv(intervalLength) * intervalLength
         lastIntervalStart = maxValue.intdiv(intervalLength) * intervalLength

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/LongIntervalHelper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/LongIntervalHelper.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020-2021 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata
+
+import grails.util.Pair
+
+
+class LongIntervalHelper extends AbstractIntervalHelper<Long> {
+
+
+    LongIntervalHelper(Long minValue, Long maxValue) {
+        super(minValue, maxValue)
+    }
+
+    @Override
+    void calculateInterval() {
+
+        difference = maxValue - minValue
+
+        if (difference <= 1) {
+            intervalLength = 1
+        } else if (1 < difference && difference <= 5 ) {
+            intervalLength = 1
+        } else if (5 < difference && difference <= 10 ) {
+            intervalLength = 2
+        } else if (10 < difference && difference <= 20 ) {
+            intervalLength = 5
+        } else if (20 < difference && difference <= 100 ) {
+            intervalLength = 10
+        } else if (100 < difference && difference <= 200 ) {
+            intervalLength = 20
+        } else if (200 < difference && difference <= 1000 ) {
+            intervalLength = 100
+        } else if (1000 < difference && difference <= 2000 ) {
+            intervalLength = 200
+        } else if (2000 < difference && difference <= 10000 ) {
+            intervalLength = 1000
+        } else if (10000 < difference && difference <= 20000 ) {
+            intervalLength = 2000
+        } else if (20000 < difference && difference <= 100000 ) {
+            intervalLength = 10000
+        } else if (100000 < difference && difference <= 200000 ) {
+            intervalLength = 20000
+        } else if (200000 < difference && difference <= 1000000 ) {
+            intervalLength = 100000
+        } else if (1000000 < difference && difference <= 2000000 ) {
+            intervalLength = 200000
+        } else if (2000000 < difference && difference <= 10000000 ) {
+            intervalLength = 1000000
+        } else if (10000000 < difference && difference <= 20000000 ) {
+            intervalLength = 2000000
+        } else if (20000000 < difference && difference <= 100000000 ) {
+            intervalLength = 10000000
+        } else {
+            Double base = Math.log10((Double) ((maxValue - minValue)  / 10))
+            intervalLength = (Integer) Math.pow(10, Math.ceil(base))
+        }
+
+        firstIntervalStart = minValue.intdiv(intervalLength) * intervalLength
+        //For negative minima which do not align with an interval start, shift the interval one step to the left
+        if (Math.abs(minValue % intervalLength) > 0 && minValue < 0) {
+            firstIntervalStart = firstIntervalStart - intervalLength
+        }
+        lastIntervalStart = maxValue.intdiv(intervalLength) * intervalLength
+        if (Math.abs(maxValue % intervalLength) > 0 && maxValue < 0) {
+            lastIntervalStart = lastIntervalStart - intervalLength
+        }
+
+    }
+
+    @Override
+    void calculateIntervalStarts() {
+        intervalStarts = []
+        Long currNum = firstIntervalStart
+        while(currNum <= lastIntervalStart) {
+            intervalStarts.add(currNum)
+            currNum += intervalLength
+        }
+    }
+
+    @Override
+    void calculateIntervals() {
+        intervals = new LinkedHashMap()
+        intervalStarts.each { start ->
+            Long finish = start + intervalLength
+            String label = "" + start + labelSeparator + finish
+            intervals[label] = (new Pair(start, finish))
+        }
+    }
+}
+

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/SummaryMetadataHelper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/summarymetadata/SummaryMetadataHelper.groovy
@@ -29,7 +29,7 @@ import java.time.OffsetDateTime
 class SummaryMetadataHelper {
 
 
-    static SummaryMetadata createSummaryMetadataFromMap(User user, String headerName, String description, Map<String, Integer> valueDistribution ) {
+    static SummaryMetadata createSummaryMetadataFromMap(User user, String headerName, String description, Map<String, Long> valueDistribution ) {
         SummaryMetadata summaryMetadata = new SummaryMetadata(
                 label: headerName,
                 description: description,


### PR DESCRIPTION
- Add generic support for sampling in queries. Subclasses can provide vendor specific SQL for sampling, by extending SamplingStrategy
- Generic support for extended properties / comments
- Fix various bugs found in the interval helpers, mainly related to calculation of intervals with negative values. Tests are added separately in mdm-plugin-testing-utils
- Change various integers to longs, add a LongIntervalHelper
- Add summary metadata for detected enumeration values