### PR TITLE
gh-9 Skip empty strings '' for enumerations. Save summary metadata to…

### DIFF
--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/AbstractDatabaseDataModelImporterProviderService.groovy
@@ -40,7 +40,6 @@ import uk.ac.ox.softeng.maurodatamapper.datamodel.provider.importer.DataModelImp
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.AbstractIntervalHelper
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.DateIntervalHelper
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.DecimalIntervalHelper
-import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.IntegerIntervalHelper
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.LongIntervalHelper
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.summarymetadata.SummaryMetadataHelper
 import uk.ac.ox.softeng.maurodatamapper.security.User
@@ -890,7 +889,7 @@ abstract class AbstractDatabaseDataModelImporterProviderService<S extends Databa
         if (isColumnForLongSummary(dt)) {
             return new LongIntervalHelper((Long) minMax.aValue, (Long) minMax.bValue)
         } else if (isColumnForIntegerSummary(dt)) {
-            return new IntegerIntervalHelper((Integer) minMax.aValue, (Integer) minMax.bValue)
+            return new LongIntervalHelper((Long) minMax.aValue, (Long) minMax.bValue)
         } else if (isColumnForDateSummary(dt)) {
             return new DateIntervalHelper(((java.util.Date) minMax.aValue).toLocalDateTime(), ((java.util.Date) minMax.bValue).toLocalDateTime())
         } else if (isColumnForDecimalSummary(dt)) {


### PR DESCRIPTION
… data class as well as data element

Closes #9 

1. When counting or selecting distinct enumeration values, append ```WHERE {column} <> ''```to the queries, to prevent empty values being converted into null enumerations. This does not affect summary metadata, which still includes counts for empty strings.
2. Save summary metadata to the data class as well as the data element
3. Use the LongIntervalHelper when dealing with integers. When you have a large negative minimum (Integer) and a large positive maximum (Integer), the difference between them can be Long.