### PR TITLE
gh-12 Reorder parameters

### DIFF
--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelImporterProviderServiceParameters.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelImporterProviderServiceParameters.groovy
@@ -56,42 +56,6 @@ abstract class DatabaseDataModelImporterProviderServiceParameters<K extends Data
     String databaseNames
 
     @ImportParameterConfig(
-        displayName = 'Detect Enumerations',
-        description = 'Whether to treat columns with small numbers of unique values as enumerations',
-        order = 5,
-        optional = true,
-        group = @ImportGroupConfig(
-                name = 'Database Import Details',
-                order = 2
-        )
-    )
-    Boolean detectEnumerations = false
-
-    @ImportParameterConfig(
-        displayName = 'Maximum Enumerations',
-        description = 'The maximum number of unique values to be interpreted as a defined enumeration',
-        order = 6,
-        optional = true,
-        group = @ImportGroupConfig(
-                name = 'Database Import Details',
-                order = 2
-        )
-    )
-    Integer maxEnumerations = 20
-
-    @ImportParameterConfig(
-            displayName = 'Calculate Summary Metadata',
-            description = 'Whether to calculate summary metadata',
-            order = 6,
-            optional = true,
-            group = @ImportGroupConfig(
-                    name = 'Database Import Details',
-                    order = 2
-            )
-    )
-    Boolean calculateSummaryMetadata = false
-
-    @ImportParameterConfig(
         displayName = 'Database Host',
         description = 'The hostname of the server that is running the database.',
         order = 2,
@@ -144,6 +108,42 @@ abstract class DatabaseDataModelImporterProviderServiceParameters<K extends Data
             order = 1
         ))
     Boolean databaseSSL
+
+    @ImportParameterConfig(
+        displayName = 'Detect Enumerations',
+        description = 'Treat columns with small numbers of unique values as enumerations?',
+        order = 1,
+        optional = true,
+        group = @ImportGroupConfig(
+            name = 'Summarisation',
+            order = 5
+        )
+    )
+    Boolean detectEnumerations = false
+
+    @ImportParameterConfig(
+        displayName = 'Maximum Enumerations',
+        description = 'The maximum number of unique values to be interpreted as a defined enumeration',
+        order = 2,
+        optional = true,
+        group = @ImportGroupConfig(
+            name = 'Summarisation',
+            order = 5
+        )
+    )
+    Integer maxEnumerations = 20
+
+    @ImportParameterConfig(
+        displayName = 'Calculate Summary Metadata',
+        description = 'Calculate summary metadata?',
+        order = 3,
+        optional = true,
+        group = @ImportGroupConfig(
+            name = 'Summarisation',
+            order = 5
+        )
+    )
+    Boolean calculateSummaryMetadata = false
 
     Integer getDatabasePort() {
         databasePort = databasePort ?: defaultPort

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelWithSamplingImporterProviderServiceParameters.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelWithSamplingImporterProviderServiceParameters.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020-2021 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.plugins.database
+
+import uk.ac.ox.softeng.maurodatamapper.core.provider.importer.parameter.config.ImportGroupConfig
+import uk.ac.ox.softeng.maurodatamapper.core.provider.importer.parameter.config.ImportParameterConfig
+
+import javax.sql.DataSource
+
+// @CompileStatic
+abstract class DatabaseDataModelWithSamplingImporterProviderServiceParameters<K extends DataSource> extends DatabaseDataModelImporterProviderServiceParameters {
+
+    @ImportParameterConfig(
+        displayName = 'Sample Threshold',
+        description = [
+            'If the approximate number of rows in a table or view exceeds this threshold, then use sampling when detecting enumerations',
+            'and computing summary metadata. A value of 0, which is the default, means that sampling will not be used.',
+            'Sampling is done using vendor specific SQL.'],
+        order = 4,
+        optional = true,
+        group = @ImportGroupConfig(
+            name = 'Sampling',
+            order = 6
+        )
+    )
+    Integer sampleThreshold = 0
+
+    @ImportParameterConfig(
+        displayName = 'Sample Percentage',
+        description = [
+            'If sampling, the percentage of rows to use as a sample. If the sampling threshold is > 0 but no',
+            'value is supplied for Sample Percentage, a default value of 1% will be used.'
+        ],
+        order = 5,
+        optional = true,
+        group = @ImportGroupConfig(
+            name = 'Sampling',
+            order = 6
+        )
+    )
+    BigDecimal samplePercent = 1
+}


### PR DESCRIPTION
Better order the parameters by:
- Moving the 'Detect Enumerations', 'Maximum Enumerations' and 'Calculate Summary Metadata' parameters into their own group called 'Summarisation'. 
- Move the 'Sample Percentage' and 'Sample Threshold' parameters into a separate subclass so that they can be used more DRYly in the SQL Server, PostgreSQL and Oracle plugins (but not MySQL, as this does not support sampling)
- Make Sample Percentage optional

Example for SQL Server:

<img width="1109" alt="parameters_example_sql_server" src="https://user-images.githubusercontent.com/20016570/150559877-7b2bf1e8-6683-40a5-b95d-c3285c09b74f.png">

'Maximum Enumerations' and 'Detect Enumerations' are displayed in the wrong order, but I cannot see how to fix that.