### PR TITLE
Improve performance of validation for database imports

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ targetCompatibility=17
 artifactory_contextUrl=https://jenkins.cs.ox.ac.uk/artifactory
 mdmGradlePluginVersion=1.2.0
 # Mauro Data Mapper
-mdmCoreVersion=5.2.0-SNAPSHOT
+mdmCoreVersion=5.3.0-SNAPSHOT
 # Grails
 grailsVersion=5.1.9
 grailsGradlePluginVersion=5.1.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ targetCompatibility=17
 artifactory_contextUrl=https://jenkins.cs.ox.ac.uk/artifactory
 mdmGradlePluginVersion=1.2.0
 # Mauro Data Mapper
-mdmCoreVersion=5.2.0
+mdmCoreVersion=5.2.0-SNAPSHOT
 # Grails
 grailsVersion=5.1.9
 grailsGradlePluginVersion=5.1.5

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelImporterProviderServiceParameters.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/DatabaseDataModelImporterProviderServiceParameters.groovy
@@ -234,6 +234,8 @@ abstract class DatabaseDataModelImporterProviderServiceParameters<K extends Data
     )
     String ignoreColumnsForSummaryMetadata
 
+    boolean providerHasSavedModels = true
+
     Integer getDatabasePort() {
         databasePort = databasePort ?: defaultPort
         databasePort


### PR DESCRIPTION
- Shallow validate populated collections instead of deep validating imported model
- Save model in importer and set providerHasSavedModels flag